### PR TITLE
Fixed user login issue on OCI

### DIFF
--- a/src/api/src/main/java/api/Application.java
+++ b/src/api/src/main/java/api/Application.java
@@ -1,6 +1,8 @@
 package api;
 
+import io.micronaut.core.annotation.TypeHint;
 import io.micronaut.runtime.Micronaut;
+import io.micronaut.security.authentication.ServerAuthentication;
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.enums.SecuritySchemeIn;
 import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
@@ -13,6 +15,10 @@ import io.swagger.v3.oas.annotations.security.SecurityScheme;
                 version = "1.0",
                 description = "Micronaut MuShop API"
         )
+)
+@TypeHint(
+        value = {ServerAuthentication.class},
+        accessType = {TypeHint.AccessType.ALL_PUBLIC}
 )
 @SecurityScheme(type = SecuritySchemeType.HTTP, name = Application.BASIC_AUTH, scheme = "basic")
 @SecurityScheme(type = SecuritySchemeType.APIKEY, name = Application.COOKIE_AUTH, in = SecuritySchemeIn.COOKIE, paramName = "SESSION")

--- a/src/api/src/main/java/api/auth/LoginController.java
+++ b/src/api/src/main/java/api/auth/LoginController.java
@@ -15,7 +15,6 @@
  */
 package api.auth;
 
-import api.model.MuUserDetails;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.context.event.ApplicationEvent;
 import io.micronaut.context.event.ApplicationEventPublisher;
@@ -101,7 +100,7 @@ class LoginController {
                         if (authenticationResponse.isAuthenticated() && authenticationResponse.isAuthenticated()) {
                             Authentication authentication = authenticationResponse.getAuthentication().get();
                             eventPublisher.publishEvent(new LoginSuccessfulEvent(authentication));
-                            return loginHandler.loginSuccess(new MuUserDetails((String)authentication.getAttributes().get("id"), authentication.getName()), request);
+                            return loginHandler.loginSuccess(authentication, request);
                         } else {
                             eventPublisher.publishEvent(new LoginFailedEvent(authenticationResponse));
                             return loginHandler.loginFailed(authenticationResponse, request);

--- a/src/api/src/main/java/api/auth/LoginController.java
+++ b/src/api/src/main/java/api/auth/LoginController.java
@@ -15,6 +15,7 @@
  */
 package api.auth;
 
+import api.model.MuUserDetails;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.context.event.ApplicationEvent;
 import io.micronaut.context.event.ApplicationEventPublisher;
@@ -100,7 +101,7 @@ class LoginController {
                         if (authenticationResponse.isAuthenticated() && authenticationResponse.isAuthenticated()) {
                             Authentication authentication = authenticationResponse.getAuthentication().get();
                             eventPublisher.publishEvent(new LoginSuccessfulEvent(authentication));
-                            return loginHandler.loginSuccess(authentication, request);
+                            return loginHandler.loginSuccess(new MuUserDetails((String)authentication.getAttributes().get("id"), authentication.getName()), request);
                         } else {
                             eventPublisher.publishEvent(new LoginFailedEvent(authenticationResponse));
                             return loginHandler.loginFailed(authenticationResponse, request);


### PR DESCRIPTION
The user login process fails because the user's id is not added to the session stored in redis after successful authentication, which happens because a serialization of `io.micronaut.security.authentication.ServerAuthentication` instance doesn't include the user id when running in a native image (probably reflection issues).

The user registration process doesn't have the same issue because `io.micronaut.security.authentication.ClientAuthentication` (actually MuUserDetails which extends ClientAuthentication) is used instead of `ServerAuthentication` and serialization is successfully completed (the user id is added to the redis session).

The quick fix for this issue is to use `ClientAuthentication` (actually MuUserDetails) for login too.