### PR TITLE
Renamed `h2` env name to `app` in the `app` subproject

### DIFF
--- a/src/catalogue/app/src/main/java/catalogue/Application.java
+++ b/src/catalogue/app/src/main/java/catalogue/Application.java
@@ -34,7 +34,7 @@ public class Application {
     public static void main(String[] args) {
         Micronaut.build(args)
                 .mainClass(Application.class)
-                .defaultEnvironments("h2")
+                .defaultEnvironments("app")
                 .start();
     }
 }

--- a/src/catalogue/app/src/main/resources/application-app.yml
+++ b/src/catalogue/app/src/main/resources/application-app.yml
@@ -1,3 +1,17 @@
+micronaut:
+  metrics:
+    export:
+      prometheus:
+        enabled: true
+        descriptions: true
+        step: PT1M
+
+endpoints:
+  prometheus:
+    enabled: true
+    sensitive: false
+    details-visible: ANONYMOUS
+
 datasources:
   default:
     url: jdbc:h2:mem:devDb;LOCK_TIMEOUT=10000;DB_CLOSE_ON_EXIT=FALSE

--- a/src/catalogue/app/src/main/resources/application.yml
+++ b/src/catalogue/app/src/main/resources/application.yml
@@ -20,15 +20,6 @@ micronaut:
     categories:
       initial-capacity: 20
   metrics:
-    export:
-      prometheus:
-        enabled: true
-        descriptions: true
-        step: PT1M
-      oraclecloud:
-        enabled: false
-      cloudwatch:
-        enabled: false
     binders:
       cache:
         enabled: true

--- a/src/catalogue/aws/build.gradle
+++ b/src/catalogue/aws/build.gradle
@@ -66,7 +66,7 @@ dockerBuild {
 }
 
 dockerBuildNative {
-  images = ["iad.ocir.io/cloudnative-devrel/micronaut-showcase/mushop/${project.parent.name}-${project.name}-native:$project.version"]
+    images = ["iad.ocir.io/cloudnative-devrel/micronaut-showcase/mushop/${project.parent.name}-${project.name}-native:$project.version"]
 }
 
 graalvmNative {

--- a/src/catalogue/aws/src/test/resources/application-test.yml
+++ b/src/catalogue/aws/src/test/resources/application-test.yml
@@ -1,3 +1,9 @@
+micronaut:
+  metrics:
+    export:
+      cloudwatch:
+        enabled: false
+
 datasources:
   default:
     url: jdbc:tc:mysql:8:///db

--- a/src/catalogue/oci/build.gradle
+++ b/src/catalogue/oci/build.gradle
@@ -65,7 +65,7 @@ dockerBuild {
 }
 
 dockerBuildNative {
-  images = ["iad.ocir.io/cloudnative-devrel/micronaut-showcase/mushop/${project.parent.name}-${project.name}-native:$project.version"]
+    images = ["iad.ocir.io/cloudnative-devrel/micronaut-showcase/mushop/${project.parent.name}-${project.name}-native:$project.version"]
 }
 
 graalvmNative {

--- a/src/catalogue/oci/src/test/resources/application-test.yml
+++ b/src/catalogue/oci/src/test/resources/application-test.yml
@@ -1,3 +1,9 @@
+micronaut:
+  metrics:
+    export:
+      oraclecloud:
+        enabled: false
+
 datasources:
   default:
     url: jdbc:tc:oracle:thin:@/xe


### PR DESCRIPTION
Since the Prometheus registry is used only in the `app` subproject (`aws` subproject is using CloudWatch registry, `oci` subproject is using OracleCloud registry), I moved prometheus settings from `application.yml` to `application-h2.yml` and then renamed `application-h2.yml` to `application-app.yml` (since that file contains not only h2 settings but prometheus settings too). If you think the `app` env name is not a good choice, let me know and I will change it.
