### PR TITLE
Fixed 'User is not authorized to perform: kafka:DescribeCluster on resource' issue

### DIFF
--- a/deploy/complete/aws-cloudformation/mushop.yml
+++ b/deploy/complete/aws-cloudformation/mushop.yml
@@ -107,6 +107,7 @@ Resources:
               - Effect: Allow
                 Action:
                   - "kafka-cluster:*"
+                  - "kafka:DescribeCluster"
                 Resource: !Ref MSKClusterArn
 
 

--- a/deploy/complete/helm-chart/mushop/charts/events/templates/events-job.yaml
+++ b/deploy/complete/helm-chart/mushop/charts/events/templates/events-job.yaml
@@ -18,6 +18,7 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
       restartPolicy: Never
+      serviceAccountName: {{ .Values.global.serviceAccount | default .Values.serviceAccount | default (printf "default") }}
       containers:
         # create topic
         - name: init


### PR DESCRIPTION
The mushop events chart runs a job (only in AWS) whose goal is to create a kafka topic but it was failing with the following issue:
```
An error occurred (AccessDeniedException) when calling the DescribeCluster operation: User: arn:aws:sts::049906870230:assumed-role/eks-quickstart-ManagedNodeInstance/i-0653c0537b3fd34bc is not authorized to perform: kafka:DescribeCluster on resource
```
Changes:
- added the `kafka:DescribeCluster` action to the `mushop-service-policy` which is attached to the `MuShopServiceIamRole` and used by the `mushop-service` service account
- added the `mushop-service` service account to the events job pod