### PR TITLE
GraalVM 22.2 error for oracle cloud function

### DIFF
--- a/src/functions/newsletter-subscription/build.gradle
+++ b/src/functions/newsletter-subscription/build.gradle
@@ -62,6 +62,7 @@ graalvmNative {
     binaries.configureEach {
         buildArgs.add("--initialize-at-build-time=newsletter.subscription")
         buildArgs.add("--static")
+        buildArgs.add("--add-exports=org.graalvm.nativeimage.builder/com.oracle.svm.core.jni=ALL-UNNAMED")
     }
 }
 


### PR DESCRIPTION
Fix for graalvm native image build error for oracle cloud function used in newsletter-subscription function (https://github.com/oracle-quickstart/oci-micronaut/actions/runs/3360675120/jobs/5570386160).