### PR TITLE
Fixed `api` tests and github job (deploying carts openjdk and graalvm images)

### DIFF
--- a/.github/workflows/java-ci.yml
+++ b/.github/workflows/java-ci.yml
@@ -190,11 +190,12 @@ jobs:
         working-directory: src/${{ matrix.project-path }}
         run: |
           if [ -f "mvnw" ]; then
-          if [ "${{ matrix.project-path }}" == "carts" ]; then
-              ./mvnw deploy -Dpackaging=docker -Djib.from.image=phx.ocir.io/oraclelabs/micronaut-showcase/mushop/base/graalvm-ce:java11-21.1.0 -Ddocker.image.suffix=graalvm --no-transfer-progress
-            else
-              ./mvnw deploy -Dpackaging=docker -Djib.from.image=ghcr.io/graalvm/graalvm-ce:java11-21.1.0 -Ddocker.image.suffix=graalvm --no-transfer-progress
-          fi
+            # Install only the `lib` module to the local repository so it can be used for building `app`, `aws` and `oci` GraalVM images
+            ./mvnw install -pl -app,-aws,-oci
+            # Build and deploy `app`, `aws` and `oci` GraalVM images
+            ./mvnw deploy -Dpackaging=docker -Djib.from.image=phx.ocir.io/oraclelabs/micronaut-showcase/mushop/base/graalvm-ce:java11-21.1.0 -Ddocker.image.suffix=graalvm --no-transfer-progress -pl app
+            ./mvnw deploy -Dpackaging=docker -Djib.from.image=phx.ocir.io/oraclelabs/micronaut-showcase/mushop/base/graalvm-ce:java11-21.1.0 -Ddocker.image.suffix=graalvm --no-transfer-progress -pl aws
+            ./mvnw deploy -Dpackaging=docker -Djib.from.image=phx.ocir.io/oraclelabs/micronaut-showcase/mushop/base/graalvm-ce:java11-21.1.0 -Ddocker.image.suffix=graalvm --no-transfer-progress -pl oci
           elif [ -f "gradlew" ]; then
             ./gradlew dockerPush --no-daemon
           fi
@@ -203,11 +204,12 @@ jobs:
         working-directory: src/${{ matrix.project-path }}
         run: |
           if [ -f "mvnw" ]; then
-            if [ "${{ matrix.project-path }}" == "carts" ]; then
-              ./mvnw deploy -Dpackaging=docker -Djib.from.image=phx.ocir.io/oraclelabs/micronaut-showcase/mushop/base/openjdk:16-alpine --no-transfer-progress
-            else
-              ./mvnw deploy -Dpackaging=docker --no-transfer-progress
-            fi
+            # Install only the `lib` module to the local repository so it can be used for building `app`, `aws` and `oci` OpenJdk images
+            ./mvnw install -pl -app,-aws,-oci
+            # Build and deploy `app`, `aws` and `oci` OpenJdk images
+            ./mvnw deploy -Dpackaging=docker -Djib.from.image=phx.ocir.io/oraclelabs/micronaut-showcase/mushop/base/openjdk:16-alpine --no-transfer-progress -pl app
+            ./mvnw deploy -Dpackaging=docker -Djib.from.image=phx.ocir.io/oraclelabs/micronaut-showcase/mushop/base/openjdk:16-alpine --no-transfer-progress -pl aws
+            ./mvnw deploy -Dpackaging=docker -Djib.from.image=phx.ocir.io/oraclelabs/micronaut-showcase/mushop/base/openjdk:16-alpine --no-transfer-progress -pl oci
           elif [ -f "gradlew" ]; then
             ./gradlew dockerPush -PjavaBaseImage=openjdk --no-daemon
           fi

--- a/src/api/src/test/java/api/AbstractDatabaseServiceTest.java
+++ b/src/api/src/test/java/api/AbstractDatabaseServiceTest.java
@@ -7,15 +7,10 @@ import io.micronaut.http.annotation.Post;
 import io.micronaut.http.client.annotation.Client;
 import io.micronaut.test.support.TestPropertyProvider;
 
-import java.sql.Connection;
-import java.sql.DriverManager;
-import java.sql.SQLException;
-
 import org.junit.jupiter.api.AfterAll;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.MongoDBContainer;
 import org.testcontainers.containers.Network;
-import org.testcontainers.containers.OracleContainer;
 import org.testcontainers.containers.wait.strategy.LogMessageWaitStrategy;
 import org.testcontainers.utility.DockerImageName;
 
@@ -24,7 +19,6 @@ import java.util.Map;
 
 abstract class AbstractDatabaseServiceTest implements TestPropertyProvider {
 
-    static OracleContainer oracleContainer;
     static MongoDBContainer mongoDBContainer;
     static GenericContainer<?> natsContainer;
     static GenericContainer<?> serviceContainer;
@@ -34,9 +28,6 @@ abstract class AbstractDatabaseServiceTest implements TestPropertyProvider {
     @AfterAll
     static void cleanup() {
         serviceContainer.stop();
-        if (oracleContainer != null) {
-            oracleContainer.stop();
-        }
         if (mongoDBContainer != null) {
             mongoDBContainer.stop();
         }
@@ -46,28 +37,17 @@ abstract class AbstractDatabaseServiceTest implements TestPropertyProvider {
     }
 
     @NonNull
-    protected Map<String, String> getProperties(boolean useOracleDB, boolean useMongoDB, boolean useNats) {
-        if (useOracleDB) {
-            startOracleContainer();
-        }
+    protected Map<String, String> getProperties(boolean useMongoDB, boolean useNats) {
         if (useMongoDB) {
             startMongoDBContainer();
         }
         if (useNats) {
             startNatsContainer();
         }
-        startServiceContainer(useOracleDB, useMongoDB, useNats);
+        startServiceContainer(useMongoDB, useNats);
         return Map.of(
                 "micronaut.http.services.mushop-" + getServiceId() + ".url", "http://" + serviceContainer.getHost() + ":" + serviceContainer.getFirstMappedPort()
         );
-    }
-
-    private void startOracleContainer() {
-        oracleContainer = new OracleContainer("gvenzl/oracle-xe:slim")
-                .usingSid()
-                .withNetwork(Network.SHARED)
-                .withNetworkAliases("oracledb");
-        oracleContainer.start();
     }
 
     private void startMongoDBContainer() {
@@ -87,14 +67,8 @@ abstract class AbstractDatabaseServiceTest implements TestPropertyProvider {
         natsContainer.start();
     }
 
-    private void startServiceContainer(boolean useOracleDB, boolean useMongoDB, boolean useNats) {
+    private void startServiceContainer(boolean useMongoDB, boolean useNats) {
         Map<String, String> env = new HashMap<>();
-        if (useOracleDB) {
-            env.put("DATASOURCES_DEFAULT_URL", "jdbc:oracle:thin:system/oracle@oracledb:1521:xe");
-            env.put("DATASOURCES_DEFAULT_DRIVER_CLASS_NAME", oracleContainer.getDriverClassName());
-            env.put("DATASOURCES_DEFAULT_USERNAME", oracleContainer.getUsername());
-            env.put("DATASOURCES_DEFAULT_PASSWORD", oracleContainer.getPassword());
-        }
         if (useMongoDB) {
             env.put("MONGODB_URI", "mongodb://mongodb-local:27017/test");
         }
@@ -110,7 +84,8 @@ abstract class AbstractDatabaseServiceTest implements TestPropertyProvider {
     }
 
     protected DockerImageName composeServiceDockerImage() {
-        return DockerImageName.parse("iad.ocir.io/cloudnative-devrel/micronaut-showcase/mushop/" + getServiceId() + "-" + defaultDockerImageServiceType.name().toLowerCase() + ":" + getServiceVersion());
+        return DockerImageName.parse("phx.ocir.io/oraclelabs/micronaut-showcase/mushop/" +
+                getServiceId() + "-app-" + defaultDockerImageServiceType.name().toLowerCase() + ":" + getServiceVersion());
     }
 
     protected int getServiceExposedPort() {

--- a/src/api/src/test/java/api/CartsServiceAnonymousTest.java
+++ b/src/api/src/test/java/api/CartsServiceAnonymousTest.java
@@ -52,10 +52,9 @@ public class CartsServiceAnonymousTest extends AbstractDatabaseServiceTest {
     @NonNull
     @Override
     public Map<String, String> getProperties() {
-        boolean useOracleDB = false;
         boolean useMongoDB = true;
         boolean useNats = false;
-        return getProperties(useOracleDB, useMongoDB, useNats);
+        return getProperties(useMongoDB, useNats);
     }
 
     @Test

--- a/src/api/src/test/java/api/CartsServiceTest.java
+++ b/src/api/src/test/java/api/CartsServiceTest.java
@@ -52,10 +52,9 @@ public class CartsServiceTest extends AbstractDatabaseServiceTest {
     @NonNull
     @Override
     public Map<String, String> getProperties() {
-        boolean useOracleDB = false;
         boolean useMongoDB = true;
         boolean useNats = false;
-        return getProperties(useOracleDB, useMongoDB, useNats);
+        return getProperties(useMongoDB, useNats);
     }
 
     @Test

--- a/src/api/src/test/java/api/CatalogueServiceTest.java
+++ b/src/api/src/test/java/api/CatalogueServiceTest.java
@@ -30,10 +30,9 @@ public class CatalogueServiceTest extends AbstractDatabaseServiceTest {
     @NonNull
     @Override
     public Map<String, String> getProperties() {
-        boolean useOracleDB = true;
         boolean useMongoDB = false;
         boolean useNats = false;
-        return getProperties(useOracleDB, useMongoDB, useNats);
+        return getProperties(useMongoDB, useNats);
     }
 
     @Test

--- a/src/api/src/test/java/api/OrdersServiceTest.java
+++ b/src/api/src/test/java/api/OrdersServiceTest.java
@@ -31,10 +31,9 @@ public class OrdersServiceTest extends AbstractDatabaseServiceTest {
     @NonNull
     @Override
     public Map<String, String> getProperties() {
-        boolean useOracleDB = true;
         boolean useMongoDB = false;
         boolean useNats = true;
-        return getProperties(useOracleDB, useMongoDB, useNats);
+        return getProperties(useMongoDB, useNats);
     }
 
     @BeforeAll

--- a/src/api/src/test/java/api/PlaceOrderTest.java
+++ b/src/api/src/test/java/api/PlaceOrderTest.java
@@ -109,10 +109,9 @@ public class PlaceOrderTest extends AbstractDatabaseServiceTest {
     @NonNull
     @Override
     public Map<String, String> getProperties() {
-        boolean useOracleDB = false;
         boolean useMongoDB = true;
         boolean useNats = false;
-        return getProperties(useOracleDB, useMongoDB, useNats);
+        return getProperties(useMongoDB, useNats);
     }
 
     @MockBean(api.services.CartsService.CatalogueClient.class)

--- a/src/api/src/test/java/api/UsersServiceTest.java
+++ b/src/api/src/test/java/api/UsersServiceTest.java
@@ -41,10 +41,9 @@ public class UsersServiceTest extends AbstractDatabaseServiceTest {
     @NonNull
     @Override
     public Map<String, String> getProperties() {
-        boolean useOracleDB = true;
         boolean useMongoDB = false;
         boolean useNats = false;
-        return getProperties(useOracleDB, useMongoDB, useNats);
+        return getProperties(useMongoDB, useNats);
     }
 
     @Test


### PR DESCRIPTION
Changes:
- replaced `cloudnative-devrel` with `oraclelabs` tenancy for images pulled by `api` tests
- removed Oracle DB from api tests since H2 is used in `app` images
- fixed deployment of carts openjdk and graalvm images