### PR TITLE
Fixed usage of web identity credentials when native images run in AWS

### DIFF
--- a/src/carts/aws/src/main/java/mushop/carts/AwsApplication.java
+++ b/src/carts/aws/src/main/java/mushop/carts/AwsApplication.java
@@ -1,8 +1,14 @@
 package mushop.carts;
 
 import io.micronaut.context.env.Environment;
+import io.micronaut.core.annotation.TypeHint;
 import io.micronaut.runtime.Micronaut;
+import software.amazon.awssdk.services.sts.internal.StsWebIdentityCredentialsProviderFactory;
 
+@TypeHint(
+        value = {StsWebIdentityCredentialsProviderFactory.class},
+        accessType = {TypeHint.AccessType.ALL_PUBLIC_CONSTRUCTORS}
+)
 public class AwsApplication {
 
     public static void main(String[] args) {

--- a/src/catalogue/aws/src/main/java/catalogue/AwsApplication.java
+++ b/src/catalogue/aws/src/main/java/catalogue/AwsApplication.java
@@ -1,8 +1,14 @@
 package catalogue;
 
 import io.micronaut.context.env.Environment;
+import io.micronaut.core.annotation.TypeHint;
 import io.micronaut.runtime.Micronaut;
+import software.amazon.awssdk.services.sts.internal.StsWebIdentityCredentialsProviderFactory;
 
+@TypeHint(
+        value = {StsWebIdentityCredentialsProviderFactory.class},
+        accessType = {TypeHint.AccessType.ALL_PUBLIC_CONSTRUCTORS}
+)
 public class AwsApplication {
     public static void main(String[] args) {
         Micronaut.build(args)

--- a/src/events/src/main/java/events/Application.java
+++ b/src/events/src/main/java/events/Application.java
@@ -1,14 +1,20 @@
 package events;
 
+import io.micronaut.core.annotation.TypeHint;
 import io.micronaut.runtime.Micronaut;
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.info.Info;
+import software.amazon.awssdk.services.sts.internal.StsWebIdentityCredentialsProviderFactory;
 
 @OpenAPIDefinition(
         info = @Info(
                 title = "events-api",
                 version = "1.0"
         )
+)
+@TypeHint(
+        value = {StsWebIdentityCredentialsProviderFactory.class},
+        accessType = {TypeHint.AccessType.ALL_PUBLIC_CONSTRUCTORS}
 )
 public class Application {
 

--- a/src/orders/aws/src/main/java/mushop/orders/AwsApplication.java
+++ b/src/orders/aws/src/main/java/mushop/orders/AwsApplication.java
@@ -1,8 +1,14 @@
 package mushop.orders;
 
 import io.micronaut.context.env.Environment;
+import io.micronaut.core.annotation.TypeHint;
 import io.micronaut.runtime.Micronaut;
+import software.amazon.awssdk.services.sts.internal.StsWebIdentityCredentialsProviderFactory;
 
+@TypeHint(
+        value = {StsWebIdentityCredentialsProviderFactory.class},
+        accessType = {TypeHint.AccessType.ALL_PUBLIC_CONSTRUCTORS}
+)
 public class AwsApplication {
     public static void main(String[] args) {
         Micronaut.build(args)

--- a/src/user/aws/src/main/java/user/AwsApplication.java
+++ b/src/user/aws/src/main/java/user/AwsApplication.java
@@ -1,8 +1,14 @@
 package user;
 
 import io.micronaut.context.env.Environment;
+import io.micronaut.core.annotation.TypeHint;
 import io.micronaut.runtime.Micronaut;
+import software.amazon.awssdk.services.sts.internal.StsWebIdentityCredentialsProviderFactory;
 
+@TypeHint(
+        value = {StsWebIdentityCredentialsProviderFactory.class},
+        accessType = {TypeHint.AccessType.ALL_PUBLIC_CONSTRUCTORS}
+)
 public class AwsApplication {
     public static void main(String[] args) {
         Micronaut.build(args)


### PR DESCRIPTION
The Carts, Catalogue, Events, User and Orders mushop micronaut services fail to start when their native images are deployed to AWS. The services fail to start with the following errors:
```
i.m.a.s.SecretsManagerKeyValueFetcher - SecretsManagerException User: arn:aws:sts::049906870230:assumed-role/eks-quickstart-ManagedNodeInstance/i-0a966426f2028a414 is not authorized to perform: secretsmanager:ListSecrets because no identity-based policy allows the secretsmanager:ListSecrets action
```
```
io.micronaut.runtime.Micronaut - Error starting Micronaut server: Error reading distributed configuration from AWS Parameter Store: User: arn:aws:sts::049906870230:assumed-role/eks-quickstart-ManagedNodeInstance/i-0a966426f2028a414 is not authorized to perform: ssm:GetParameters on resource: arn:aws:ssm:us-east-1:049906870230:parameter/config/application because no identity-based policy allows the ssm:GetParameters action (Service: Ssm, Status Code: 400, Request ID: 407ce70c-18c0-4cc4-9636-ccb0984529a0)
```
The GetParameters and ListSecrets fails because
```
arn:aws:sts::049906870230:assumed-role/eks-quickstart-ManagedNodeInstance/i-0a966426f2028a414
```
is used for authentication instead of
```
arn:aws:iam::049906870230:role/MuShopServiceIamRole
```
The services have AWS_WEB_IDENTITY_TOKEN_FILE and AWS_ROLE_ARN environment variables ready for usage, but the `software.amazon.awssdk.auth.credentials.WebIdentityTokenFileCredentialsProvider` class, which is responsible for using those values, calls `WebIdentityCredentialsUtils.factory()` which further uses reflection to load
```
software.amazon.awssdk.services.sts.internal.StsWebIdentityCredentialsProviderFactory
```
which is the main reason why AWS_WEB_IDENTITY_TOKEN_FILE and AWS_ROLE_ARN are not used for authentication.

The quick fix is to register the StsWebIdentityCredentialsProviderFactory class for reflection using TypeHint annotation.

Also, maybe we should register the software.amazon.awssdk.services.sts.internal.StsWebIdentityCredentialsProviderFactory class in https://github.com/micronaut-projects/micronaut-aws/blob/master/aws-sdk-v2/src/main/resources/META-INF/native-image/io.micronaut.aws/micronaut-aws-sdk-v2/reflect-config.json or some other micronaut module. I also found this:
```
https://github.com/aws/aws-sdk-java-v2/issues/2985
```