### PR TITLE
Fixed chart displayed on About MuShop page when services deployed to OCI

### DIFF
--- a/src/storefront/src/scripts/shop/about.js
+++ b/src/storefront/src/scripts/shop/about.js
@@ -126,6 +126,9 @@ export class MuServiceChart extends MuMx.compose(null, ViewTemplateMixin) {
         setCord(data.BUCKET, col(4.5), row(0));
         setCord(data.STREAMING, col(5.5), row(0), { label: { offset: [0, 10] }});
         setCord(data.ATP, col(7.5), row(0));
+
+        setCord(data.APIGW, col(6.5), row(0));
+        setCord(data.EMAIL, col(8), row(2));
       }
 
 
@@ -145,11 +148,9 @@ export class MuServiceChart extends MuMx.compose(null, ViewTemplateMixin) {
       setCord(data.ORDERS, col(6), row(2), skew.java);
       setCord(data.NATS, col(7), row(2));
       setCord(data.FULFILLMENT, col(7), row(1));
-      //
-      // setCord(data.APIGW, col(6.5), row(0));
+
       setCord(data.SUBSCRIBE, col(8), row(1));
-      // setCord(data.EMAIL, col(8), row(2));
-      //
+
       setCord(data.PAYMENT, col(7), row(3), skew.go);
       setCord(data.USER, col(5), row(1));
     }


### PR DESCRIPTION
**Details**: Javascript code which sets coordinates for API Gateway and Email services was commented out as part of changes that were done for displaying AWS chart (https://github.com/oracle-quickstart/oci-micronaut/commit/49e146206095fa87b78f4a6c3a80e2fa0142bfa3#diff-5c6cb1d0f11edf91620d65e07253920df061ee4ac5fdc14951c75f6e6bc06691R149), which caused OCI chart display failure because commented out services are used in OCI service links.
**Fix**: Moved code which sets coordinates for API Gateway and Email services to javascript block which sets coordinates just for services running in OCI.