### PR TITLE
Fixed docs for AWS deployment

### DIFF
--- a/deploy/complete/Makefile
+++ b/deploy/complete/Makefile
@@ -1,9 +1,4 @@
-.PHONY: clean publish-aws oraclecloud-build
-
-#
-# Global AWS configuration
-AWS_S3_BUCKET                  := micronaut-mushop-aws
-AWS_S3_REGION                  := us-west-2
+.PHONY: clean oraclecloud-artefacts aws-artefacts
 
 #
 # Include external configuration
@@ -21,13 +16,10 @@ oraclecloud-artefacts:
 
 #
 # AWS
-aws-publish:
-	mkdir -p ./aws-cloudformation/charts
-	helm package -d ./aws-cloudformation/charts ./helm-chart/mushop
-	helm repo index ./aws-cloudformation/charts
-	aws s3 --recursive cp ./aws-cloudformation s3://$(AWS_S3_BUCKET)/$(VERSION)
-
-
-
-
-
+aws-artefacts:
+	mkdir -p ${VERSION}/charts
+	cp ./aws-cloudformation/* ./${VERSION}
+	helm package -d ${VERSION}/charts ./helm-chart/mushop
+	helm repo index ${VERSION}/charts
+	zip -rm mushop-aws-v${VERSION}.zip ${VERSION}
+	cp mushop-aws-v${VERSION}.zip mushop-aws-latest.zip

--- a/src/api/app/src/test/java/api/AssetsServiceTest.java
+++ b/src/api/app/src/test/java/api/AssetsServiceTest.java
@@ -1,7 +1,7 @@
 package api;
 
-//TODO: uncomment once we have published assets-app-graalvm:2.0.0-SNAPSHOT image
-//@MicronautTest
-//public class AssetsServiceTest extends AbstractAssetsServiceTest {
-public class AssetsServiceTest {
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+
+@MicronautTest
+public class AssetsServiceTest extends AbstractAssetsServiceTest {
 }

--- a/src/docs/content/quickstart/aws-cloudformation.md
+++ b/src/docs/content/quickstart/aws-cloudformation.md
@@ -20,15 +20,19 @@ AWS account with configured billing.
 Note that the charges will be applied since used services are not part of the [AWS Free Tier](https://aws.amazon.com/free/?all-free-tier.sort-by=item.additionalFields.SortRank&all-free-tier.sort-order=asc&awsf.Free%20Tier%20Types=*all&awsf.Free%20Tier%20Categories=*all). 
 {{% /alert %}}
 
-## Create stack
-To start with the [AWS Cloudformation](https://aws.amazon.com/cloudformation/) click on the following button (currently disabled for maintenance):
-</br>
-<!-- [![Launch Stack](https://s3.amazonaws.com/cloudformation-examples/cloudformation-launch-stack.png)](https://console.aws.amazon.com/cloudformation/home?#/stacks/new?stackName=MicronautMuShop&templateURL=https://micronaut-mushop-aws.s3.us-west-2.amazonaws.com/3.1.0/mushop-entrypoint.yaml) -->
+## Create S3 bucket
+Create a new S3 bucket and upload the latest [CloudFormation templates](https://github.com/oracle-quickstart/oci-micronaut/releases/latest/download/mushop-aws-latest.zip) to the new bucket.
+The CloudFormation templates should be uploaded together with its parent directory whose name defines CloudFormation templates version, for example: `3.1.0`
 
-Proceed to specify stack details:
+## Create stack
+To start with the [AWS Cloudformation](https://aws.amazon.com/cloudformation/), create a new stack using S3 URL of the uploaded mushop-entrypoint.yaml template file. 
+</br>
+
 {{% width 1-2 %}}
 ![Mushop stack create](../images/aws/aws-stack-create.png)
 {{% /width %}}
+
+Proceed next to the specify stack details.
 
 ## Specify stack details
 


### PR DESCRIPTION
Changes:

- Modified Makefile to zip CloudFormation templates, which have been uploaded to the [github releases](https://github.com/oracle-quickstart/oci-micronaut/releases) (similar to zipped content for OCI Resource Manager)
- Modified docs to provide info how zipped CloudFormation templates should be used in CloudFormation stack
- Uncommented api AssetsServiceTest